### PR TITLE
Replace experiment host to use tschweiz home

### DIFF
--- a/client_side/.infrastructure/setup.sh
+++ b/client_side/.infrastructure/setup.sh
@@ -33,7 +33,7 @@ fi
 TASK_TIME_LIMIT=300
 
 # Establish the server information
-SERVER_HOST="https://homes.cs.washington.edu/~atran35"
+SERVER_HOST="https://homes.cs.washington.edu/~tschweiz"
 # Establish survey URL
 EXPERIMENT_HOME_URL="${SERVER_HOST}/research/bash_user_experiment"
 

--- a/client_side/README.txt
+++ b/client_side/README.txt
@@ -1,4 +1,4 @@
 Welcome to the Bash User Experiment!
 
 Please see the instructions on the experiment website here:
-https://homes.cs.washington.edu/~atran35/research/bash_user_experiment/
+https://homes.cs.washington.edu/~tschweiz/research/bash_user_experiment/


### PR DESCRIPTION
Replaces the current experiment host page (https://homes.cs.washington.edu/~atran35/research/bash_user_experiment/)
with my own (https://homes.cs.washington.edu/~tschweiz/research/bash_user_experiment/)