### PR TITLE
Fix outdated Travis badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/anhnamtran/tellina_user_experiment.svg?branch=master)](https://travis-ci.org/anhnamtran/tellina_user_experiment)
+[![Build Status](https://travis-ci.com/TellinaTool/tellina_user_experiment.svg?branch=master)](https://travis-ci.com/TellinaTool/tellina_user_experiment)
 # Tellina User Experiment
 Tellina is a natural language -> command translation tool. Tellina accepts a natural language description of file system operations and displays a ranked list of bash one-liner suggestions made by the model. The user can scroll down the web page to explore more suggestions.
 


### PR DESCRIPTION
The Travis badge was pointing to the old Tellina repository. See #13.