### PR TITLE
Add rational for using Meld

### DIFF
--- a/experiment_design_doc.md
+++ b/experiment_design_doc.md
@@ -122,7 +122,7 @@ Throughout the experiment, the users will be interacting with the bash shell, Me
 Diffs could be shown in the bash shell where the participants will be completing the tasks. However, diffs shown
 in the terminal (unified diffs) can be hard to understand, especially for participants unfamiliar with diffs. 
 On the other hand, graphical diffs are easier to understand and more accessible. Thus, the study will use Meld to
-show diffs.
+show diffs. This requires that the subjects have Meld installed on the system they will use to participate to the study.
 
 ### User Interface
 

--- a/experiment_design_doc.md
+++ b/experiment_design_doc.md
@@ -118,6 +118,12 @@ Throughout the experiment, the users will be interacting with the bash shell, Me
   - They will use the web browser to find resources and interact with Tellina
     (when applicable).
 
+#### Unified vs Graphical diffs
+Diffs could be shown in the bash shell where the participants will be completing the tasks. However, diffs shown
+in the terminal (unified diffs) can be hard to understand, especially for participants unfamiliar with diffs. 
+On the other hand, graphical diffs are easier to understand and more accessible. Thus, the study will use Meld to
+show diffs.
+
 ### User Interface
 
 The Bash shell for the experiment will have all built-in commands, prompts, and


### PR DESCRIPTION
This PR adds the rational of why Meld is used to show diffs rather than using the terminal directly.