### PR TITLE
Rename experiment package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ ZIP=zip -qr
 # Directory of distribution which is a symbolic link to CLIENT_DIR.
 # This allows naming the directory distributed to the users without directly
 # changing the CLIENT_DIR's name.
-DIST_NAME=bash_user_experiment
+DIST_NAME=experiment
 
 # The name of the distribution.
 ZIP_DIST_NAME=$(DIST_NAME).zip

--- a/experiment_design_doc.md
+++ b/experiment_design_doc.md
@@ -224,7 +224,7 @@ of the archive is described bellow.
 The directory structure for the client side after extracting the ZIP archive
 will look similar to:
 ```
-user_experiment/
+experiment/
 |__.infrastructure
 |  |__setup.sh        - Bash script that sources function definition files, sets
 |  |                    variables for the experiment (paths to scripts, to files,

--- a/index.html
+++ b/index.html
@@ -14,7 +14,6 @@ variety of tools (man pages, Google, etc.) to help you solve it.</p>
   using a machine with a graphical display, Bash 3.0 or higher, and Meld
   installed.</p>
 <p>Once all of those prerequisites are met, please download the following
-  <code>ZIP</code> file: <a
-    href="bash_user_experiment.zip">bash_user_experiment.zip</a></p>
+  <code>ZIP</code> file: <a href="experiment.zip">experiment.zip</a></p>
 </body>
 </html>


### PR DESCRIPTION
The previous name was confusing and unnecessarily long. This one short and straight to the point. It also helps avoid confusion with the name of the folder where the experiment is hosted on the internet.