### PR TITLE
Host folder rename & Host server update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,10 +26,10 @@ TEST_DIR=$(INFRA_DIR)/test
 # Website
 
 # The machine that is hosting the website
-HOST=atran35@attu.cs.washington.edu
+HOST=tschweiz@attu.cs.washington.edu
 
 # The website's directory on HOST
-HOST_DIR=/cse/web/homes/atran35/research
+HOST_DIR=/cse/web/homes/tschweiz/research
 
 # Can be something else if needed
 WEBSITE_NAME=$(DIST_NAME)

--- a/client_side/.infrastructure/setup.sh
+++ b/client_side/.infrastructure/setup.sh
@@ -35,7 +35,7 @@ TASK_TIME_LIMIT=300
 # Establish the server information
 SERVER_HOST="https://homes.cs.washington.edu/~tschweiz"
 # Establish survey URL
-EXPERIMENT_HOME_URL="${SERVER_HOST}/research/bash_user_experiment"
+EXPERIMENT_HOME_URL="${SERVER_HOST}/research/bash_experiment"
 
 POST_HANDLER="${EXPERIMENT_HOME_URL}/server_side/post_handler/post_handler.php"
 

--- a/client_side/README.txt
+++ b/client_side/README.txt
@@ -1,4 +1,4 @@
 Welcome to the Bash User Experiment!
 
 Please see the instructions on the experiment website here:
-https://homes.cs.washington.edu/~tschweiz/research/bash_user_experiment/
+https://homes.cs.washington.edu/~tschweiz/research/bash_experiment/

--- a/server_side/post_handler/example
+++ b/server_side/post_handler/example
@@ -1,5 +1,5 @@
-HOST="host.cs.washington.edu"
-ROUTE="/path/to/post_hander.php"
+HOST="https://homes.cs.washington.edu"
+ROUTE="~tschweiz/research/bash_experiment/server_side/post_handler/post_handler.php"
 
 USER_ID="jdoe@csevm"
 TASK_ORDER=0


### PR DESCRIPTION
This PR updates the host folder's name and updates the remaining host server location. 
The simplification of the folder's name removes the emphasis on the 'user' part of the experiment, which the participants don't need to know about.