### PR TITLE
Update infrastructure organization's documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,24 @@ This repository contains the infrastructure for formally conducting user experim
 - [**data_set**](https://github.com/TellinaTool/tellina_user_experiment/tree/master/dataset): contains the scripts used to produce the data set for the user experiment (referenced as _taskset_).
 - [**experiment_design_doc.md**](https://github.com/TellinaTool/tellina_user_experiment/blob/master/experiment_design_doc.md): instructions for setting up and conducting the user experiments.
 
-## Distributing experiment
+
+## Creating a new host
+
+1. Clone the repository locally
+2. Update the Makefile in the local repo with the intended `HOST` and `HOST_DIR`.
+3. Update `SERVER_HOST` in `client_side/.infrastructure/setup.sh` with the new host.
+4. Update `client_side/README.txt` with the new host.
+3. Create `HOST_DIR` on `HOST`, and clone the repository into `HOST_DIR`.
+
+    a. Rename `HOST_DIR/repo-name` to `DIST_NAME` (the directory name for the repository on `HOST` should match `DIST_NAME` in the local repo)
+4. (Optional) Create a `HOST_DIR/staging` and repeat step 3 there if you would like to have a testing website.
+5. Run  `make all publish-distribution`
+6. Update the permission of `$HOST/$HOST_DIR/server_side/log.csv` with `chmod 666 log.csv`
+
+Once a new host has been created, the link in `telina_user_experiment/client_side/README.md` can be updated to wherever the new site is.
+
+## Distributing the experiment
+
 To distribute the files, run `make` or `make all`. This will run all tests and create the `.zip` file for distribution at the root of this folder.
   - The `DIST_NAME` variable in the [Makefile](Makefile) specifies the name of the `.zip` file that will be created.
   - The structure of the experiment archive is specified in [the experiment design doc](experiment_design_doc.md#directory-structure).

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repository contains the infrastructure for formally conducting user experim
 - [**server_side**](https://github.com/TellinaTool/tellina_user_experiment/tree/master/client_side): contains the files to be distributed to the users of the experiment.
 - [**client_side**](https://github.com/TellinaTool/tellina_user_experiment/tree/master/server_side): contains the code used for the server side of the experiment, this includes both the post handler and the post-processor.
 - [**data_set**](https://github.com/TellinaTool/tellina_user_experiment/tree/master/dataset): contains the scripts used to produce the data set for the user experiment (referenced as _taskset_).
-- [**experiment_design_doc.md**](https://github.com/TellinaTool/tellina_user_experiment/blob/master/experiment_design_doc.md): instructions for setting up and conducting the user experiments.
+- [**infrastructure.md**](https://github.com/TellinaTool/tellina_user_experiment/blob/master/infrastructure.md): describes the technical infrastructure and implementation of the user experiment.
 
 
 ## Creating a new host

--- a/README.md
+++ b/README.md
@@ -34,3 +34,14 @@ To distribute the files, run `make` or `make all`. This will run all tests and c
 ### Requirements
 - [Bats](https://github.com/bats-core/bats-core)
 - [zip](https://linux.die.net/man/1/zip) (if it's not already installed on your system)
+
+## Previously
+In a past experiment, people were given descriptions of file system operations, and asked to write bash commands to perform the operations.  The experimental group had access to Tellina, web search, and man pages; the control group had access only to web search and man pages. Measurements were done on whether subjects successfully complete the tasks, and the amount of time that it takes to complete the tasks. A post-task questionnaire obtained qualitative feedback.
+
+We need to redo the experiment, for a few reasons.
+1. Tellina has changed since the user study was performed.  Tellina has better
+   accuracy and handles more commands.  It would not be compelling to report an
+   experiment on an implementation that has since been superseded.
+2. The user study was relatively small (around 30 subjects), so the experimental
+   results were not always statistically significant.  With a larger pool of
+   subjects, the results will be more compelling.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Build Status](https://travis-ci.com/TellinaTool/tellina_user_experiment.svg?branch=master)](https://travis-ci.com/TellinaTool/tellina_user_experiment)
 # Tellina User Experiment
-Tellina is a natural language -> command translation tool. Tellina accepts a natural language description of file system operations and displays a ranked list of bash one-liner suggestions made by the model. The user can scroll down the web page to explore more suggestions.
+Tellina is a natural language -> command translation tool. Tellina accepts a natural language description of file system operations and displays a ranked list of bash one-liner suggestions made by the model. The user can scroll down the web page to explore more suggestions. http://tellina.rocks/
 
 This repository contains the infrastructure for formally conducting user experiments for Tellina.
 

--- a/experiment_design_doc.md
+++ b/experiment_design_doc.md
@@ -1,30 +1,5 @@
 # Tellina User Study Design Doc
-
-## Introduction
-
-Tellina is a natural language -> command translation tool.  Tellina accepts a
-natural language description of file system operations, and displays a ranked
-list of bash one-liner suggestions made by the model. The user can scroll down
-the web page to explore more suggestions.
-
-In an experiment, people were given
-descriptions of file system operations, and asked to write bash commands to
-perform the operations.  The experimental group had access to Tellina, web
-search, and man pages; the control group had access only to web search and
-man pages. Measurements were done on whether subjects successfully complete the
-tasks, and the amount of time that it takes to complete the tasks.
-A post-task questionnaire obtained qualitative feedback.
-
-We need to redo the experiment, for a few reasons.
-1. Tellina has changed since the user study was performed.  Tellina has better
-   accuracy and handles more commands.  It would not be compelling to report an
-   experiment on an implementation that has since been superseded.
-2. The user study was relatively small (around 30 subjects), so the experimental
-   results were not always statistically significant.  With a larger pool of
-   subjects, the results will be more compelling.
-
-This design document describes a new infrastructure for the user design, as the
-previous one was buggy.
+This design document describes the infrastructure for the user experiment.
 
 ## Overview
 

--- a/experiment_design_doc.md
+++ b/experiment_design_doc.md
@@ -410,23 +410,6 @@ command is executed
 
 The client side is tested using [Bats](https://github.com/bats-core/bats-core).
 
-## Maintenance
-
-### Creating a new host
-
-1. Clone the repository locally
-2. Update the Makefile in the local repo with the intended `HOST` and `HOST_DIR`.
-3. Update `SERVER_HOST` in `client_side/.infrastructure/setup.sh` with the new host.
-4. Update `client_side/README.txt` with the new host.
-3. Create `HOST_DIR` on `HOST`, and clone the repository into `HOST_DIR`.
-
-    a. Rename `HOST_DIR/repo-name` to `DIST_NAME` (the directory name for the repository on `HOST` should match `DIST_NAME` in the local repo)
-4. (Optional) Create a `HOST_DIR/staging` and repeat step 3 there if you would like to have a testing website.
-5. Run  `make all publish-distribution`
-6. Update the permission of `$HOST/$HOST_DIR/server_side/log.csv` with `chmod 666 log.csv`
-
-Once a new host has been created, the link in `telina_user_experiment/client_side/README.md` can be updated to wherever the new site is.
-
 ## Risks and Concerns
 - Do we want to automatically reset the file system after each command?
   - Encourages one-liner solutions.
@@ -439,4 +422,3 @@ Once a new host has been created, the link in `telina_user_experiment/client_sid
   - TellinaTool/bash_task_interface.git
   - TellinaTool/user_study_chrome_extension.git
   - TellinaTool/resource-website.git
-

--- a/infrastructure.md
+++ b/infrastructure.md
@@ -1,4 +1,4 @@
-# Tellina User Study Design Doc
+# Infrastructure Design
 This design document describes the infrastructure for the user experiment.
 
 ## Overview


### PR DESCRIPTION
This pull request moves the documentation on how to create a new web host to the README as instructions regarding how to use the artifacts of a repository are generally found there (as opposed to a design document).

The second change transforms `experiment_design.md` to `infrastructure.md` as the document is really about the infrastructure design and not the experimental design as evidence by the line: 

> This design document describes a new infrastructure for the user design, as the previous one was buggy.

Additionally, the current authoritative source of experimental design is in the initial google doc or the latest version of the paper currently being written.