### PR TITLE
Add survey link to homepage and experiment client

### DIFF
--- a/client_side/.infrastructure/infrastructure.sh
+++ b/client_side/.infrastructure/infrastructure.sh
@@ -100,7 +100,7 @@ end_experiment() {
   cd "${EXP_DIR}"
 
   echo "Congratulations! You have completed the interactive portion of the experiment."
-  echo "Please fill out the survey on the experiment home page."
+  echo "Please fill out our short survey at https://forms.gle/xjAqf1YrvfKMZunL8 (5 minutes)."
 
   return 0
 }

--- a/index.html
+++ b/index.html
@@ -48,6 +48,9 @@
   </ol>
   When you start the experiment, follow the prompts in your terminal. You will have 2 training questions to familiarize yourself with the tool and then the real tasks.
   </p>
+
+  <h2>After the experiment</h2>
+  When you have finished the experiment, please complete this <a href="http://https://forms.gle/xjAqf1YrvfKMZunL8">short survey</a> (5 minutes).
 </body>
 
 </html>


### PR DESCRIPTION
This pull request adds the link of the exit survey on the experiment's home page and in the experiment client.