### PR TITLE
Fix .gitkeep files being deleted after tests

### DIFF
--- a/client_side/.infrastructure/infrastructure.sh
+++ b/client_side/.infrastructure/infrastructure.sh
@@ -96,7 +96,7 @@ end_experiment() {
   trap - DEBUG
 
   # Remove all variable files.
-  find ${INFRA_DIR} -type f -name ".*" -delete
+  find ${INFRA_DIR} -type f -name ".*" ! -name ".gitkeep" -delete
   cd "${EXP_DIR}"
 
   echo "Congratulations! You have completed the interactive portion of the experiment."


### PR DESCRIPTION
Workaround for #18. `end_experiment()` now deletes all files except `.gitkeep`. 

I feel this solution is not the best given that the responsibility should really be on the test harness itself to restore the files to their default state after running the test suite.

I'm not sure how to restore the files at the end of a test. Should we copy the filesystem in a dedicated directory for tests that we then remove safely after the test suite? That way, none of the files in the original fs is touched and we can keep the behavior of `end_experiment()` to delete all files.