### PR TITLE
Add bash environment script pre-requisite

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -39,6 +39,7 @@
     <ol>
       <li>Download <a href="experiment.zip">experiment.zip</a> in a convenient folder on your CSE Linux Home VM.</li>
       <li>Unzip with <code>$ unzip experiment.zip</code></li>
+      <li>Make sure to use a Bash environment <code>$ bash</code></li>
       <li>Start the experiment <code>$ source experiment/configure</code></li>
     </ol>
     When you start the experiment, follow the prompts in your terminal. You will have 2 training questions to familiarize yourself with the tool and then the real tasks.


### PR DESCRIPTION
Adds an instruction for users to use a bash environment before sourcing the start of the experiment. Prevent #29 from happening. 